### PR TITLE
Rename toFileString() method to convertToFileString()

### DIFF
--- a/src/main/java/alisa/Storage.java
+++ b/src/main/java/alisa/Storage.java
@@ -84,7 +84,7 @@ public class Storage {
     public void syncFile(TaskList taskList) throws AlisaException {
         try {
             FileWriter fw = new FileWriter(this.filePath);
-            fw.write(taskList.toFileString());
+            fw.write(taskList.convertToFileString());
             fw.close();
         } catch (IOException e) {
             throw new AlisaException("Couldn't update file!!");

--- a/src/main/java/alisa/task/Deadline.java
+++ b/src/main/java/alisa/task/Deadline.java
@@ -46,7 +46,7 @@ public class Deadline extends Task{
      * @return String of task type, task status, task description, and due date.
      */
     @Override
-    public String toFileString() {
+    public String convertToFileString() {
         return "D | " + this.getFileStatus() + " | "
                 + this.getTask() + " | " + dueDate + "\n";
     }

--- a/src/main/java/alisa/task/Event.java
+++ b/src/main/java/alisa/task/Event.java
@@ -50,7 +50,7 @@ public class Event extends Task {
      * @return String of task type, task status, and task description, and task start and end time.
      */
     @Override
-    public String toFileString() {
+    public String convertToFileString() {
         return "E | " + this.getFileStatus() + " | "
                 + this.getTask() + " | " + startTime + "-" + endTime + "\n";
     }

--- a/src/main/java/alisa/task/Task.java
+++ b/src/main/java/alisa/task/Task.java
@@ -66,7 +66,7 @@ public abstract class Task {
      *
      * @return String of task details.
      */
-    public abstract String toFileString();
+    public abstract String convertToFileString();
 
     /**
      * Indicates if the task description contains the keyword.

--- a/src/main/java/alisa/task/TaskList.java
+++ b/src/main/java/alisa/task/TaskList.java
@@ -53,7 +53,7 @@ public class TaskList {
      */
     public String markTask(int index) throws AlisaException {
         try {
-            taskList.get(index-1).markAsDone();
+            taskList.get(index - 1).markAsDone();
             return "Nice! I've marked this task as done:\n" + taskList.get(index-1);
         } catch (IndexOutOfBoundsException e) {
             throw new AlisaException("The task you want to mark as done doesn't exist!");
@@ -69,7 +69,7 @@ public class TaskList {
      */
     public String unmarkTask(int index) throws AlisaException {
         try {
-            taskList.get(index-1).markAsNotDone();
+            taskList.get(index - 1).markAsNotDone();
             return "OK, I've marked this task as not done yet:\n" + taskList.get(index-1);
         } catch (IndexOutOfBoundsException e) {
             throw new AlisaException("The task you want to mark as not done doesn't exist!");
@@ -110,10 +110,10 @@ public class TaskList {
      *
      * @return String of all tasks and their details in txt file format.
      */
-    public String toFileString() {
+    public String convertToFileString() {
         String fileText = "";
         for (Task task : taskList) {
-            fileText += task.toFileString();
+            fileText += task.convertToFileString();
         }
         return fileText;
     }

--- a/src/main/java/alisa/task/Todo.java
+++ b/src/main/java/alisa/task/Todo.java
@@ -32,7 +32,7 @@ public class Todo extends Task {
      * @return String of task type, task status, and task description.
      */
     @Override
-    public String toFileString() {
+    public String convertToFileString() {
         return "T | " + this.getFileStatus()
                 + " | " + this.getTask() + "\n";
     }


### PR DESCRIPTION
The method name wasn't used as a verb and didn't sufficiently describe its function since there's another similar method called toString().

Let's rename the method by adding the word convert to further explain what it does.