### PR TITLE
Add new edit feature to tasks

### DIFF
--- a/src/main/java/alisa/Parser.java
+++ b/src/main/java/alisa/Parser.java
@@ -1,6 +1,7 @@
 package alisa;
 
 import alisa.command.Command;
+import alisa.command.EditCommand;
 import alisa.command.MarkCommand;
 import alisa.command.UnmarkCommand;
 import alisa.command.AddCommand;
@@ -45,6 +46,11 @@ public class Parser {
                 return new ExitCommand();
             case "find":
                 return new FindCommand(commandArray[1]);
+            case "edit":
+                //edit [1 description "hello there"]
+                String[] editDescription = commandArray[1].split(" ", 3);
+                String editedContent = editDescription[2].substring(1, editDescription[2].length() - 1);
+                return new EditCommand(Integer.parseInt(editDescription[0]), editDescription[1], editedContent);
             default:
                 throw new AlisaException("Sorry, I didn't quite catch that. Put in a command that I understand");
         }

--- a/src/main/java/alisa/command/EditCommand.java
+++ b/src/main/java/alisa/command/EditCommand.java
@@ -1,0 +1,30 @@
+package alisa.command;
+
+import alisa.Storage;
+import alisa.Ui;
+import alisa.exception.AlisaException;
+import alisa.task.TaskList;
+
+public class EditCommand extends Command {
+    private int index;
+    private String featureToEdit;
+    private String editedContent;
+
+    public EditCommand(int index, String featureToEdit, String editedContent) {
+        this.index = index;
+        this.featureToEdit = featureToEdit;
+        this.editedContent = editedContent;
+    }
+
+    @Override
+    public void execute(TaskList taskList, Ui ui, Storage storage) throws AlisaException {
+        String message = taskList.editTask(index, featureToEdit, editedContent);
+        ui.showMessage(message);
+    }
+
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}
+

--- a/src/main/java/alisa/task/Deadline.java
+++ b/src/main/java/alisa/task/Deadline.java
@@ -50,4 +50,13 @@ public class Deadline extends Task{
         return "D | " + this.getFileStatus() + " | "
                 + this.getTask() + " | " + dueDate + "\n";
     }
+
+    public void changeDueDate(String date) throws AlisaException {
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-mm-dd hh:mm");
+            dueDate = LocalDateTime.parse(date, formatter);
+        } catch (DateTimeParseException e) {
+            throw new AlisaException("Please write the deadline in the following format: yyyy-mm-dd hh:mm");
+        }
+    }
 }

--- a/src/main/java/alisa/task/Event.java
+++ b/src/main/java/alisa/task/Event.java
@@ -54,4 +54,22 @@ public class Event extends Task {
         return "E | " + this.getFileStatus() + " | "
                 + this.getTask() + " | " + startTime + "-" + endTime + "\n";
     }
+
+    public void changeStartTime(String time) throws AlisaException {
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-mm-dd hh:mm");
+            startTime = LocalDateTime.parse(time, formatter);
+        } catch (DateTimeParseException e) {
+            throw new AlisaException("Please write the deadline in the following format: yyyy-mm-dd hh:mm");
+        }
+    }
+
+    public void changeEndTime(String time) throws AlisaException {
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-mm-dd hh:mm");
+            endTime = LocalDateTime.parse(time, formatter);
+        } catch (DateTimeParseException e) {
+            throw new AlisaException("Please write the deadline in the following format: yyyy-mm-dd hh:mm");
+        }
+    }
 }

--- a/src/main/java/alisa/task/Task.java
+++ b/src/main/java/alisa/task/Task.java
@@ -1,5 +1,7 @@
 package alisa.task;
 
+import java.time.LocalDateTime;
+
 public abstract class Task {
     private String taskDescription;
     private boolean isDone;
@@ -76,5 +78,9 @@ public abstract class Task {
      */
     public boolean containsWord(String keyword) {
         return taskDescription.contains(keyword);
+    }
+
+    public void changeDescription(String description) {
+        taskDescription = description;
     }
 }

--- a/src/main/java/alisa/task/TaskList.java
+++ b/src/main/java/alisa/task/TaskList.java
@@ -1,6 +1,11 @@
 package alisa.task;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.SimpleTimeZone;
 
 import alisa.exception.AlisaException;
 
@@ -134,6 +139,58 @@ public class TaskList {
             }
         }
         return tasks;
+    }
+
+    public String editTask(int index, String featureToEdit, String editedContent) throws AlisaException {
+        try {
+            Task taskToEdit = taskList.get(index);
+            if (taskToEdit.getClass() == Todo.class) {
+                Todo editingTask = (Todo) taskToEdit;
+
+                switch (featureToEdit) {
+                case "description":
+                    editingTask.changeDescription(editedContent);
+                    break;
+                default:
+                    throw new AlisaException("That's not a feature that can be edited for this task");
+                }
+            } else if (taskToEdit.getClass() == Deadline.class) {
+                Deadline editingTask = (Deadline) taskToEdit;
+
+                switch (featureToEdit) {
+                case "description":
+                    editingTask.changeDescription(editedContent);
+                    break;
+                case "deadline":
+                    editingTask.changeDueDate(editedContent);
+                    break;
+                default:
+                    throw new AlisaException("That's not a feature that can be edited for this task");
+                }
+            } else {
+                Event editingTask = (Event) taskToEdit;
+
+                switch (featureToEdit) {
+                case "description":
+                    editingTask.changeDescription(editedContent);
+                    break;
+                case "start":
+                    editingTask.changeStartTime(editedContent);
+                    break;
+                case "end":
+                    editingTask.changeEndTime(editedContent);
+                    break;
+                default:
+                    throw new AlisaException("That's not a feature that can be edited for this task");
+                }
+            }
+
+            return "Task #" + index + " has been successfully edited. Now the task looks like this:\n"
+                    + taskList.get(index);
+
+        } catch (IndexOutOfBoundsException e) {
+            throw new AlisaException("There isn't a task that belongs to the index in the task list.");
+        }
     }
 
 }


### PR DESCRIPTION
If a user wants to edit a specific part of a task, they would need to delete the original task and then add a completely new task.

Let's add a new feature that can directly edit a part of an existing task without having to use multiple commands. For instance, in an event task, the edit command can allow just the end time to be updated.

Having an edit feature is preferable as it is easier to make direct changes to tasks that still need to be on the task list.